### PR TITLE
Support nanosecond resolution and timestamps (sec, ms, ns)

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1004,7 +1004,28 @@ func TestRandomFormat35(t *testing.T) {
 func TestHighPrecisionSeconds(t *testing.T) {
     parser := &Parser{}
     timestr := "20080227T21:26:01.123456789"
-    expect := time.Date(2008, 2, 27, 21, 26, 1, 123456000, UTCLoc) // Parser only stores microseconds, not nanoseconds
+    expect := time.Date(2008, 2, 27, 21, 26, 1, 123456789, UTCLoc)
+    check(t, parser, timestr, expect)
+}
+
+func TestSinceEpochSeconds(t *testing.T) {
+    parser := &Parser{}
+    timestr := "1332151919"
+    expect := time.Date(2012, 3, 19, 10, 11, 59, 0, UTCLoc)
+    check(t, parser, timestr, expect)
+}
+
+func TestSinceEpochMilliSeconds(t *testing.T) {
+    parser := &Parser{}
+    timestr := "1332151919123"
+    expect := time.Date(2012, 3, 19, 10, 11, 59, 123000000, UTCLoc)
+    check(t, parser, timestr, expect)
+}
+
+func TestSinceEpochNanoSeconds(t *testing.T) {
+    parser := &Parser{}
+    timestr := "1332151919123456789"
+    expect := time.Date(2012, 3, 19, 10, 11, 59, 123456789, UTCLoc)
     check(t, parser, timestr, expect)
 }
 


### PR DESCRIPTION
This commit does the following:

- Adds support for nanosecond resolution timestamps (since this is idiomatic in Go)
- Adds support for common timestamps "since epoch" -- in seconds (unix timestamp), milliseconds (Java, etc. timestamps), nanoseconds (Go, etc. timestamps).
- Fixes truncation where an hour was subtracted from the truncated time (code taken from [Russ Cox comment](https://github.com/golang/go/issues/10894#issuecomment-150758649)
 